### PR TITLE
Add and Display Additional Fields on Click and Popup Functionality to display asset details

### DIFF
--- a/Frontend/src/assets/Styles/popup.css
+++ b/Frontend/src/assets/Styles/popup.css
@@ -1,0 +1,37 @@
+.popup-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.5);
+    z-index: 999;
+  }
+  
+  .popup {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background-color: white;
+    padding: 20px;
+    border: 1px solid #ccc;
+    border-radius: 5px;
+    z-index: 1000;
+  }
+  
+  .popup h2 {
+    margin-top: 0;
+  }
+  
+  .popup p {
+    margin-bottom: 10px;
+  }
+  
+  .close {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    cursor: pointer;
+  }
+  

--- a/Frontend/src/components/AddAsset.jsx
+++ b/Frontend/src/components/AddAsset.jsx
@@ -6,9 +6,9 @@ function AddAsset({ onAdd }) {
     assetName: "",
     location: "",
     quantity: "",
+    description: "", // Add description field
   });
   const [showModal, setShowModal] = useState(false);
-  const [assetsList, setAssetsList] = useState([]);
 
   const handleChange = (e) => {
     const { name, value } = e.target;
@@ -21,10 +21,9 @@ function AddAsset({ onAdd }) {
       asset.location.trim() !== "" &&
       asset.quantity.trim() !== ""
     ) {
-      const newAssetsList = [...assetsList, asset];
-      setAssetsList(newAssetsList);
-      onAdd(asset); // You can remove this line if you don't need the parent to know about the new asset
-      setAsset({ assetName: "", location: "", quantity: "" });
+      const newAsset = { ...asset }; // Create a new asset object
+      onAdd(newAsset); // Pass the new asset to the onAdd function
+      setAsset({ assetName: "", location: "", quantity: "", description: "" }); // Reset form fields
       setShowModal(false); // Close the modal after adding asset
     }
   };
@@ -68,23 +67,21 @@ function AddAsset({ onAdd }) {
               className="add-asset-input"
               name="quantity"
             />
+            {/* Add description input */}
+            <input
+              type="text"
+              placeholder="Description"
+              value={asset.description}
+              onChange={handleChange}
+              className="add-asset-input"
+              name="description"
+            />
             <button id="submitbutton" onClick={handleAdd}>
               Submit
             </button>
           </div>
         </div>
       )}
-
-      <div className="assets-list">
-        <h3>Assets List</h3>
-        {/* <ul>
-          {assetsList.map((item, index) => (
-            <li key={index}>
-              {item.assetName} - {item.location} - {item.quantity}
-            </li>
-          ))}
-        </ul> */}
-      </div>
     </>
   );
 }

--- a/Frontend/src/components/AddAsset.jsx
+++ b/Frontend/src/components/AddAsset.jsx
@@ -6,7 +6,10 @@ function AddAsset({ onAdd }) {
     assetName: "",
     location: "",
     quantity: "",
-    description: "", // Add description field
+    subtype: "", // Add subtype field
+    startDate: "", // Add startDate field
+    finishDate: "", // Add finishDate field
+    description: "",
   });
   const [showModal, setShowModal] = useState(false);
 
@@ -19,11 +22,22 @@ function AddAsset({ onAdd }) {
     if (
       asset.assetName.trim() !== "" &&
       asset.location.trim() !== "" &&
-      asset.quantity.trim() !== ""
+      asset.quantity.trim() !== "" &&
+      asset.subtype.trim() !== "" && // Ensure subtype is not empty
+      asset.startDate.trim() !== "" && // Ensure startDate is not empty
+      asset.finishDate.trim() !== "" // Ensure finishDate is not empty
     ) {
       const newAsset = { ...asset }; // Create a new asset object
       onAdd(newAsset); // Pass the new asset to the onAdd function
-      setAsset({ assetName: "", location: "", quantity: "", description: "" }); // Reset form fields
+      setAsset({
+        assetName: "",
+        location: "",
+        quantity: "",
+        subtype: "",
+        startDate: "",
+        finishDate: "",
+        description: "",
+      }); // Reset form fields
       setShowModal(false); // Close the modal after adding asset
     }
   };
@@ -67,6 +81,33 @@ function AddAsset({ onAdd }) {
               className="add-asset-input"
               name="quantity"
             />
+            {/* Add subtype input */}
+            <input
+              type="text"
+              placeholder="Subtype"
+              value={asset.subtype}
+              onChange={handleChange}
+              className="add-asset-input"
+              name="subtype"
+            />
+            {/* Add startDate input */}
+            <input
+              type="text"
+              placeholder="Start Date"
+              value={asset.startDate}
+              onChange={handleChange}
+              className="add-asset-input"
+              name="startDate"
+            />
+            {/* Add finishDate input */}
+            <input
+              type="text"
+              placeholder="Finish Date"
+              value={asset.finishDate}
+              onChange={handleChange}
+              className="add-asset-input"
+              name="finishDate"
+            />
             {/* Add description input */}
             <input
               type="text"
@@ -85,4 +126,5 @@ function AddAsset({ onAdd }) {
     </>
   );
 }
+
 export default AddAsset;

--- a/Frontend/src/components/AssetManagement.jsx
+++ b/Frontend/src/components/AssetManagement.jsx
@@ -12,6 +12,7 @@ function AssetManagement() {
   const [editedAsset, setEditedAsset] = useState({});
   const [showEditModal, setShowEditModal] = useState(false);
   const [selectedAsset, setSelectedAsset] = useState(null);
+  const [showNextFields, setShowNextFields] = useState(false); // State to control visibility of next fields
 
   const handleAddAsset = (newAsset) => {
     setAssets([...assets, newAsset]);
@@ -43,6 +44,11 @@ function AssetManagement() {
 
   const handleClosePopup = () => {
     setSelectedAsset(null);
+    setShowNextFields(false); // Reset showNextFields state when closing popup
+  };
+
+  const handleNextClick = () => {
+    setShowNextFields(!showNextFields);
   };
 
   return (
@@ -57,6 +63,13 @@ function AssetManagement() {
               <th>Asset Name</th>
               <th>Quantity</th>
               <th>Location</th>
+              {showNextFields && (
+                <>
+                  <th>Subtype</th>
+                  <th>Start Date</th>
+                  <th>Finish Date</th>
+                </>
+              )}
               <th>Options</th>
             </tr>
           </thead>
@@ -67,6 +80,13 @@ function AssetManagement() {
                 <td>{asset.assetName}</td>
                 <td>{asset.quantity}</td>
                 <td>{asset.location}</td>
+                {showNextFields && (
+                  <>
+                    <td>{asset.subtype}</td>
+                    <td>{asset.startDate}</td>
+                    <td>{asset.finishDate}</td>
+                  </>
+                )}
                 <td>
                   <div className="asset-actions">
                     <button
@@ -82,19 +102,22 @@ function AssetManagement() {
             ))}
           </tbody>
         </table>
-        {selectedAsset && (
-          <div className="popup-overlay" onClick={handleClosePopup}>
-            <div className="popup">
-              <span className="close" onClick={handleClosePopup}>
-                &times;
-              </span>
-              <h2>Asset Details</h2>
-              <p>Serial Number: {assets.indexOf(selectedAsset) + 1}</p>
-              <p>Description: {selectedAsset.description}</p>
-            </div>
-          </div>
-        )}
+        <button onClick={handleNextClick}>
+          {showNextFields ? "Previous" : "Next"}
+        </button>
       </div>
+      {selectedAsset && (
+        <div className="popup-overlay" onClick={handleClosePopup}>
+          <div className="popup">
+            <span className="close" onClick={handleClosePopup}>
+              &times;
+            </span>
+            <h2>Asset Details</h2>
+            <p>Serial Number: {assets.indexOf(selectedAsset) + 1}</p>
+            <p>Description: {selectedAsset.description}</p>
+          </div>
+        </div>
+      )}
       {showEditModal && (
         <EditAsset
           asset={editedAsset}

--- a/Frontend/src/components/AssetManagement.jsx
+++ b/Frontend/src/components/AssetManagement.jsx
@@ -1,100 +1,109 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import AddAsset from "./AddAsset";
 import DeleteAsset from "./DeleteAsset";
 import EditAsset from "./EditAsset";
-// import SaveAsset from './SaveAsset';
 import "../assets/Styles/AssetManagement.css";
 import UniversalSearch from "./UniversalSearch";
+import "../assets/Styles/popup.css";
 
 function AssetManagement() {
-	const [assets, setAssets] = useState([]);
-	const [editIndex, setEditIndex] = useState(null);
-	const [editedAsset, setEditedAsset] = useState({});
-	const [showEditModal, setShowEditModal] = useState(false);
-	useEffect(() => {
-		const storedAssets = localStorage.getItem("assets");
-		if (storedAssets) {
-			setAssets(JSON.parse(storedAssets));
-		}
-	}, []);
+  const [assets, setAssets] = useState([]);
+  const [editIndex, setEditIndex] = useState(null);
+  const [editedAsset, setEditedAsset] = useState({});
+  const [showEditModal, setShowEditModal] = useState(false);
+  const [selectedAsset, setSelectedAsset] = useState(null);
 
-	const handleAddAsset = (newAsset) => {
-		setAssets([...assets, newAsset]);
-		localStorage.setItem("assets", JSON.stringify([...assets, newAsset]));
-	};
+  const handleAddAsset = (newAsset) => {
+    setAssets([...assets, newAsset]);
+  };
 
-	const handleEditAsset = (index) => {
-		setEditIndex(index);
-		setEditedAsset(assets[index]);
-		setShowEditModal(true);
-	};
+  const handleEditAsset = (index) => {
+    setEditIndex(index);
+    setEditedAsset(assets[index]);
+    setShowEditModal(true);
+  };
 
-	const handleSaveEdit = () => {
-		const updatedAssets = [...assets];
-		updatedAssets[editIndex] = editedAsset;
-		setAssets(updatedAssets);
-		setEditIndex(null);
-		setEditedAsset({});
-		localStorage.setItem("assets", JSON.stringify(updatedAssets));
-		setShowEditModal(false);
-	};
+  const handleSaveEdit = () => {
+    const updatedAssets = [...assets];
+    updatedAssets[editIndex] = editedAsset;
+    setAssets(updatedAssets);
+    setEditIndex(null);
+    setEditedAsset({});
+    setShowEditModal(false);
+  };
 
-	const handleDeleteAsset = (index) => {
-		const updatedAssets = assets.filter((_, i) => i !== index);
-		setAssets(updatedAssets);
-		localStorage.setItem("assets", JSON.stringify(updatedAssets));
-	};
+  const handleDeleteAsset = (index) => {
+    const updatedAssets = assets.filter((_, i) => i !== index);
+    setAssets(updatedAssets);
+  };
 
-	return (
-		<body>
-			<div>
-				<UniversalSearch />
-				<AddAsset onAdd={handleAddAsset} />
-				<div className="asset-table-container">
-					<table className="asset-table">
-						<thead>
-							<tr>
-								<th>Serial No</th>
-								<th>Asset Name</th>
-								<th>Quantity</th>
-								<th>Location</th>
-								<th>Options</th>
-							</tr>
-						</thead>
-						<tbody>
-							{assets.map((asset, index) => (
-								<tr key={index}>
-									<td>{index + 1}</td>
-									<td>{asset.assetName}</td>
-									<td>{asset.quantity}</td>
-									<td>{asset.location}</td>
-									<td>
-										<div className="asset-actions">
-											<button
-												id="editbutton"
-												onClick={() => handleEditAsset(index)}
-											>
-												Edit
-											</button>
-											<DeleteAsset onDelete={() => handleDeleteAsset(index)} />
-										</div>
-									</td>
-								</tr>
-							))}
-						</tbody>
-					</table>
+  const handleAssetClick = (index) => {
+    setSelectedAsset(assets[index]);
+  };
 
-					{showEditModal && (
-						<EditAsset
-							asset={editedAsset}
-							onEdit={setEditedAsset}
-							onSave={handleSaveEdit}
-						/>
-					)}
-				</div>
-			</div>
-		</body>
-	);
+  const handleClosePopup = () => {
+    setSelectedAsset(null);
+  };
+
+  return (
+    <>
+      <UniversalSearch />
+      <AddAsset onAdd={handleAddAsset} />
+      <div className="asset-table-container">
+        <table className="asset-table">
+          <thead>
+            <tr>
+              <th>Serial No</th>
+              <th>Asset Name</th>
+              <th>Quantity</th>
+              <th>Location</th>
+              <th>Options</th>
+            </tr>
+          </thead>
+          <tbody>
+            {assets.map((asset, index) => (
+              <tr key={index} onClick={() => handleAssetClick(index)}>
+                <td>{index + 1}</td>
+                <td>{asset.assetName}</td>
+                <td>{asset.quantity}</td>
+                <td>{asset.location}</td>
+                <td>
+                  <div className="asset-actions">
+                    <button
+                      id="editbutton"
+                      onClick={() => handleEditAsset(index)}
+                    >
+                      Edit
+                    </button>
+                    <DeleteAsset onDelete={() => handleDeleteAsset(index)} />
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        {selectedAsset && (
+          <div className="popup-overlay" onClick={handleClosePopup}>
+            <div className="popup">
+              <span className="close" onClick={handleClosePopup}>
+                &times;
+              </span>
+              <h2>Asset Details</h2>
+              <p>Serial Number: {assets.indexOf(selectedAsset) + 1}</p>
+              <p>Description: {selectedAsset.description}</p>
+            </div>
+          </div>
+        )}
+      </div>
+      {showEditModal && (
+        <EditAsset
+          asset={editedAsset}
+          onEdit={setEditedAsset}
+          onSave={handleSaveEdit}
+        />
+      )}
+    </>
+  );
 }
 
 export default AssetManagement;


### PR DESCRIPTION
This pull request introduces two key enhancements to the Asset Management feature:

Additional Fields Display: Users can now toggle the display of additional fields (subtype, start date, and finish date) in the table by clicking on the "Next" button. This functionality allows for better organization and presentation of asset data without overwhelming the user interface.
Popup Functionality: Clicking on an asset name in the table now triggers a popup displaying the asset's serial number and description. This feature provides users with convenient access to essential asset details without disrupting their workflow.
These improvements enhance the usability and functionality of the Asset Management feature, making it more intuitive and user-friendly.